### PR TITLE
Fix bug in state change without animation

### DIFF
--- a/Sources/M13Checkbox.swift
+++ b/Sources/M13Checkbox.swift
@@ -309,7 +309,7 @@ public class M13Checkbox: UIControl {
         if animated {
             manager.animate(checkState, toState: newState)
         } else {
-            manager.resetLayersForState(checkState)
+            manager.resetLayersForState(newState)
         }
     }
     


### PR DESCRIPTION
We should change the state to the new state instead keeping the current `changeState`.
